### PR TITLE
Enclose argument names inside [] in --help

### DIFF
--- a/Sources/ArgumentDescription.swift
+++ b/Sources/ArgumentDescription.swift
@@ -249,7 +249,7 @@ class Help : ErrorType, CustomStringConvertible {
     let options = descriptors.filter   { $0.type == ArgumentType.Option }
 
     if let command = command {
-      let args = arguments.map { "[\($0.name)]" }
+      let args = arguments.map { "<\($0.name)>" }
       let usage = ([command] + args).joinWithSeparator(" ")
 
       output.append("Usage:")

--- a/Sources/ArgumentDescription.swift
+++ b/Sources/ArgumentDescription.swift
@@ -249,7 +249,7 @@ class Help : ErrorType, CustomStringConvertible {
     let options = descriptors.filter   { $0.type == ArgumentType.Option }
 
     if let command = command {
-      let args = arguments.map { $0.name }
+      let args = arguments.map { "[\($0.name)]" }
       let usage = ([command] + args).joinWithSeparator(" ")
 
       output.append("Usage:")


### PR DESCRIPTION
This is more in line with traditional help output by Unix commands.

Before:

```bash
$ ./bin/ctf-generator --help
Usage:

    $ ./bin/ctf-generator Space ID Access Token
```

After:

```bash
$ ./bin/ctf-generator --help
Usage:

    $ ./bin/ctf-generator [Space ID] [Access Token]
```