### PR TITLE
Fix a potential crash when `UsageError` is thrown

### DIFF
--- a/Sources/CommandRunner.swift
+++ b/Sources/CommandRunner.swift
@@ -34,6 +34,9 @@ extension CommandType {
       let help = Help([], command: usage, group: group)
       fputs("\(help)\n", stderr)
       exit(1)
+    } catch let error as UsageError {
+      fputs("\(error)\n", stderr)
+      exit(1)
     } catch {
       fputs("\(error)\n", stderr)
       exit(1)


### PR DESCRIPTION
See neonichu/Azkaban#4

I'm not 100% sure why it is happening, but assuming that the string interpolation of `ErrorType` does something special, as it does not officially implement `StringLiteralConvertible`. According to the BT, `description` will still be called on `UsageError`, but the ivars suffer some memory corruption, leading to the crash.