### PR TITLE
Use associatedtype instead of typealias inside of a protocol definition.

### DIFF
--- a/Sources/ArgumentDescription.swift
+++ b/Sources/ArgumentDescription.swift
@@ -4,7 +4,7 @@ public enum ArgumentType {
 }
 
 public protocol ArgumentDescriptor {
-  typealias ValueType
+  associatedtype ValueType
 
   /// The arguments name
   var name:String { get }


### PR DESCRIPTION
I changed the use of `typealias` inside of the `ArgumentDescriptor` protocol definition to be `associatedtype` instead.

https://github.com/apple/swift-evolution/blob/master/proposals/0011-replace-typealias-associated.md

Address issue #23 