### PR TITLE
Switch to associatedtype for protocols

### DIFF
--- a/Sources/ArgumentDescription.swift
+++ b/Sources/ArgumentDescription.swift
@@ -5,7 +5,7 @@ public enum ArgumentType {
 
 
 public protocol ArgumentDescriptor {
-  typealias ValueType
+  associatedtype ValueType
 
   /// The arguments name
   var name:String { get }


### PR DESCRIPTION
This makes the only necessary update for warnings introduced in Swift 2.2