### PR TITLE
Rename VaradicArgument to VariadicArgument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Commander Changelog
 
+- Renamed VaradicArgument to VariadicArgument.
+
 ## 0.5.0
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Hello Kyle
 - Options - A option with a value which can be used multiple times, your command is passed an array containing all option values.
 - Flag - A boolean, on/off flag.
 - Argument - A positional argument.
-- VaradicArgument - A varadic argument
+- VariadicArgument - A variadic argument
 
 **NOTE**: *It's important to describe your arguments after options and flags so the parser can differentiate between `--option value` and `--flag argument`.*
 

--- a/Sources/ArgumentDescription.swift
+++ b/Sources/ArgumentDescription.swift
@@ -45,10 +45,8 @@ open class VariadicArgument<T : ArgumentConvertible> : ArgumentDescriptor {
   }
 }
 
-#if swift(>=3.0)
 @available(*, deprecated, message: "use VariadicArgument instead")
 typealias VaradicArgument<T : ArgumentConvertible> = VariadicArgument<T>
-#endif
 
 
 open class Argument<T : ArgumentConvertible> : ArgumentDescriptor {

--- a/Sources/ArgumentDescription.swift
+++ b/Sources/ArgumentDescription.swift
@@ -45,8 +45,10 @@ open class VariadicArgument<T : ArgumentConvertible> : ArgumentDescriptor {
   }
 }
 
+#if swift(>=3.0)
 @available(*, deprecated, message: "use VariadicArgument instead")
 typealias VaradicArgument<T : ArgumentConvertible> = VariadicArgument<T>
+#endif
 
 
 open class Argument<T : ArgumentConvertible> : ArgumentDescriptor {

--- a/Sources/ArgumentDescription.swift
+++ b/Sources/ArgumentDescription.swift
@@ -27,7 +27,7 @@ extension ArgumentConvertible {
 }
 
 
-open class VaradicArgument<T : ArgumentConvertible> : ArgumentDescriptor {
+open class VariadicArgument<T : ArgumentConvertible> : ArgumentDescriptor {
   public typealias ValueType = [T]
 
   open let name: String
@@ -44,6 +44,9 @@ open class VaradicArgument<T : ArgumentConvertible> : ArgumentDescriptor {
     return try Array<T>(parser: parser)
   }
 }
+
+@available(*, deprecated, message: "use VariadicArgument instead")
+typealias VaradicArgument<T : ArgumentConvertible> = VariadicArgument<T>
 
 
 open class Argument<T : ArgumentConvertible> : ArgumentDescriptor {


### PR DESCRIPTION
Provide typealias (and deprecation warning) for existing users.