### PR TITLE
Better ANSI support detection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Commander Changelog
 
+### Bug Fixes
+
+- Better detection of ANSI support in output tty.
+  [#43](https://github.com/kylef/Commander/issues/43)
+
 ## 0.6.0
 
 ### Enhancements

--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -13,19 +13,12 @@ protocol ANSIConvertible : Error, CustomStringConvertible {
 extension ANSIConvertible {
   func print() {
     // Check if we are in any term env and the output is a tty.
-    let termType = getEnvValue("TERM")
-    if let t = termType, t.lowercased() != "dumb" && isatty(fileno(stdout)) != 0 {
+    if let termType = getenv("TERM"), String(cString: termType).lowercased() != "dumb" &&
+      isatty(fileno(stdout)) != 0 {
       fputs("\(ansiDescription)\n", stderr)
     } else {
       fputs("\(description)\n", stderr)
     }
-  }
-
-  private func getEnvValue(_ key: String) -> String? {
-    guard let value = getenv(key) else {
-      return nil
-    }
-    return String(cString: value)
   }
 }
 

--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -12,12 +12,6 @@ protocol ANSIConvertible : Error, CustomStringConvertible {
 
 extension ANSIConvertible {
   func print() {
-    // Check if Xcode Colors is installed and enabled.
-    let xcodeColorsEnabled = (getEnvValue("XcodeColors") == "YES")
-    if xcodeColorsEnabled {
-      fputs("\(ansiDescription)\n", stderr)
-    }
-    
     // Check if we are in any term env and the output is a tty.
     let termType = getEnvValue("TERM")
     if let t = termType, t.lowercased() != "dumb" && isatty(fileno(stdout)) != 0 {

--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -12,11 +12,26 @@ protocol ANSIConvertible : Error, CustomStringConvertible {
 
 extension ANSIConvertible {
   func print() {
-    if isatty(fileno(stderr)) != 0 {
+    // Check if Xcode Colors is installed and enabled.
+    let xcodeColorsEnabled = (getEnvValue("XcodeColors") == "YES")
+    if xcodeColorsEnabled {
+      fputs("\(ansiDescription)\n", stderr)
+    }
+    
+    // Check if we are in any term env and the output is a tty.
+    let termType = getEnvValue("TERM")
+    if let t = termType, t.lowercased() != "dumb" && isatty(fileno(stdout)) != 0 {
       fputs("\(ansiDescription)\n", stderr)
     } else {
       fputs("\(description)\n", stderr)
     }
+  }
+
+  private func getEnvValue(_ key: String) -> String? {
+    guard let value = getenv(key) else {
+      return nil
+    }
+    return String(cString: value)
   }
 }
 


### PR DESCRIPTION
In SwiftGen we've just hit an issue with `ANSI support` detection in the Xcode 8 console:
https://github.com/AliSoftware/SwiftGen/issues/221

While trying to find a solution, I found the [Rainbow](https://github.com/onevcat/Rainbow) library, which has a bit more expansive tty detection:
https://github.com/onevcat/Rainbow/blob/master/Sources/OutputTarget.swift

This PR simply incorporates the extra detection into Commander.