### PR TITLE
Add Package.pins to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.build/
+Package.pins
 Packages/
 Examples/hello
 Examples/pod


### PR DESCRIPTION
This file is generated when built with the Swift compiler that is included in Xcode 8.3.