### PR TITLE
Make SubCommand public

### DIFF
--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -39,11 +39,6 @@ open class Group : CommandType {
     let name: String
     let description: String?
     let command: CommandType
-
-    init(name: String, description: String?, command: CommandType) {
-      self.name = name
-      self.description = description
-      self.command = command
     }
   }
 

--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -35,11 +35,10 @@ public func == (lhs: GroupError, rhs: GroupError) -> Bool {
 
 /// Represents a group of commands
 open class Group : CommandType {
-  struct SubCommand {
-    let name: String
-    let description: String?
-    let command: CommandType
-    }
+  public struct SubCommand {
+    public let name: String
+    public let description: String?
+    public let command: CommandType
   }
 
   var commands = [SubCommand]()


### PR DESCRIPTION
I'm using Group in a little personal project and I wanted to have a "default command" for the top level group. I did this by subclassing Group along these lines:

```swift
class DefaultableGroup < Commander.Group {
    var defaultCommand: SubCommand?
}
```

Of course to actually do this, I need SubCommand to be public. I thought others might benefit from this change as well. Or, maybe I'm taking the wrong approach and there's better way to get this effect. 

👎 👍 ❓

Thanks for your time