### PR TITLE
Add noCommand property to Group

### DIFF
--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -71,7 +71,7 @@ open class Group : CommandType {
       throw GroupError.noCommand(nil, self)
     }
 
-    guard let command = commands.filter { $0.name == name }.first else {
+    guard let command = commands.first(where: { $0.name == name }) else {
       if let unknownCommand = unknownCommand {
         return try unknownCommand(name, parser)
       } else {

--- a/Tests/CommanderTests/GroupSpec.swift
+++ b/Tests/CommanderTests/GroupSpec.swift
@@ -74,6 +74,32 @@ public func testGroup() {
       try expect(group).run(["g1", "g2"]).toThrow(GroupError.noCommand("g1 g2", subsubgroup))
     }
 
+    $0.it("calls unknownCommand property when present") {
+      let group = Group {
+        $0.unknownCommand = { (_, _) in throw GroupError.unknownCommand("gotcha!") }
+      }
+
+      try expect(group).run(["yo"]).toThrow(GroupError.unknownCommand("gotcha!"))
+    }
+
+    $0.it("calls noCommand property when present") {
+      let subgroup = Group()
+      let group = Group {
+        $0.addCommand("g1", subgroup)
+        $0.noCommand = { (_, group, _) in throw GroupError.noCommand("gotcha!", group) }
+      }
+
+      try expect(group).run([]).toThrow(GroupError.noCommand("gotcha!", group))
+      try expect(group).run(["g1"]).toThrow(GroupError.noCommand("gotcha!", subgroup))
+    }
+
+    $0.it("calls noCommand property when present") {
+      let group = Group()
+      group.noCommand = { _ in throw GroupError.noCommand("gotcha!", group) }
+
+      try expect(group).run([]).toThrow(GroupError.noCommand("gotcha!", group))
+    }
+
     $0.describe("extensions") {
       $0.it("has a convinience initialiser calling a builder closure") {
         var didRunHelpCommand = false


### PR DESCRIPTION
As an alternative to https://github.com/kylef/Commander/pull/51, this change adds a `noCommand` property to `Group`. This allows clients to override the default behavior for when no command is supplied. This may be useful as a "default command" for the group. 

For example: say you have a task-manager program. One command might be `todos ls`, which lists all the tasks still remaining. It would be useful to _also_ run "`ls` when your user simply executes `todos`, the name of the group. Overriding the `noCommand` behavior allows this.

Example usage: 

```swift
Group {
  $0.noCommand = { (path, group, parser) in
    if let path = path {
      // no command given to subgroup, so fail?
      throw GroupError.noCommand(path, group, parser)
    } else {
      // no command given,
      // run "default" behavior...
    }
  }

  // ...
}
```

I also added some tests for this and the `unknownCommand` property.