### PR TITLE
Fix compilation error in Swift 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Commander Changelog
 
+## Master
+
+### Bug Fixes
+
+- Fix compilation errors in Swift 3.
+  [#57](https://github.com/kylef/Commander/pull/57)
+
 ## 0.8.0
 
 ### Enhancements

--- a/Sources/Commander/ArgumentConvertible.swift
+++ b/Sources/Commander/ArgumentConvertible.swift
@@ -48,7 +48,7 @@ public protocol ArgumentConvertible : CustomStringConvertible {
 extension String : ArgumentConvertible {
   public init(parser: ArgumentParser) throws {
     if let value = parser.shift() {
-      self.init(value)
+      self = value
     } else {
       throw ArgumentError.missingValue(argument: nil)
     }


### PR DESCRIPTION
It seems that in Swift 3.2, calling `self.init(value)` from within the `String.init(ArgumentParser)` doesn't compile:

> 🛑 A non-failable initializer cannot delegate to failable initializer 'init' written with 'init?'

(But it does compile in Swift 4.0)

Given `value` is already a `String` extracted by `parser.shift()`, there's actually no need to call the init, as we can use `self = value` directly, which both compiles in Swift 3.2 and in Swift 4.0