### PR TITLE
Only use red color for errors if terminal supports ANSI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Commander Changelog
 
+## Master
+
+### Bug Fixes
+
+- Only print errors in red if the output terminal supports ANSI color codes.
+  [#58](https://github.com/kylef/Commander/pull/58)
+
 ## 0.8.0
 
 ### Enhancements

--- a/Sources/Commander/CommandRunner.swift
+++ b/Sources/Commander/CommandRunner.swift
@@ -38,10 +38,10 @@ extension CommandType {
       error.print()
       exit(1)
     } catch let error as CustomStringConvertible {
-      fputs("\(ANSI.red)\(error.description)\(ANSI.reset)\n", stderr)
+      ANSI.red.print(error.description, to: stderr)
       exit(1)
     } catch {
-      fputs("\(ANSI.red)Unknown error occurred.\(ANSI.reset)\n", stderr)
+      ANSI.red.print("Unknown error occurred.", to: stderr)
       exit(1)
     }
 

--- a/Sources/Commander/Error.swift
+++ b/Sources/Commander/Error.swift
@@ -13,8 +13,7 @@ protocol ANSIConvertible : Error, CustomStringConvertible {
 extension ANSIConvertible {
   func print() {
     // Check if we are in any term env and the output is a tty.
-    if let termType = getenv("TERM"), String(cString: termType).lowercased() != "dumb" &&
-      isatty(fileno(stdout)) != 0 {
+    if ANSI.isTerminalSupported {
       fputs("\(ansiDescription)\n", stderr)
     } else {
       fputs("\(description)\n", stderr)
@@ -38,5 +37,22 @@ enum ANSI: UInt8, CustomStringConvertible {
 
   var description: String {
     return "\u{001B}[\(self.rawValue)m"
+  }
+
+  static var isTerminalSupported: Bool {
+    if let termType = getenv("TERM"), String(cString: termType).lowercased() != "dumb" &&
+      isatty(fileno(stdout)) != 0 {
+      return true
+    } else {
+      return false
+    }
+  }
+
+  func print(_ string: String, to output: UnsafeMutablePointer<FILE> = stdout) {
+    if ANSI.isTerminalSupported {
+      fputs("\(self)\(string)\(ANSI.reset)\n", output)
+    } else {
+      fputs("\(string)\n", output)
+    }
   }
 }


### PR DESCRIPTION
There were some places in the code where ANSI codes where printed to `stderr` without testing if the terminal supported it.
This made error messages in the Xcode console for example to print the ANSI escapes — as the Xcode console doesn't support ANSI color codes

This change allows to print a string in a given color on `stderr` or `stdout` _only_ if the terminal supports it.