### PR TITLE
Add Package.swift for Swift 4.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Spectre",
+        "repositoryURL": "https://github.com/kylef/Spectre.git",
+        "state": {
+          "branch": null,
+          "revision": "e34d5687e1e9d865e3527dd58bc2f7464ef6d936",
+          "version": "0.8.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:4.2
+
+import PackageDescription
+
+let package = Package(
+  name: "Commander",
+  products: [
+    .library(name: "Commander", targets: ["Commander"]),
+  ],
+  dependencies: [
+    .package(url: "https://github.com/kylef/Spectre.git", from: "0.8.0"),
+  ],
+  targets: [
+    .target(name: "Commander", dependencies: []),
+    .testTarget(name: "CommanderTests", dependencies: ["Commander", "Spectre"]),
+  ],
+  swiftLanguageVersions: [.v4, .v4_2]
+)


### PR DESCRIPTION
Probably worth waiting for a new release after https://github.com/kylef/Spectre/pull/37

We can update CI to build this after 4.2 is officially released