### PR TITLE
Support positional arguments

### DIFF
--- a/Sources/Commander/ArgumentParser.swift
+++ b/Sources/Commander/ArgumentParser.swift
@@ -58,7 +58,19 @@ public final class ArgumentParser : ArgumentConvertible, CustomStringConvertible
 
   /// Initialises the ArgumentParser with an array of arguments
   public init(arguments: [String]) {
-    self.arguments = arguments.map { argument in
+    let splitArguments = arguments.split(maxSplits: 1, omittingEmptySubsequences: false) { $0 == "--" }
+    
+    let unfixedArguments: [String]
+    let fixedArguments: [String]
+    if splitArguments.count == 2, let prefix = splitArguments.first, let suffix = splitArguments.last {
+      unfixedArguments = Array(prefix)
+      fixedArguments = Array(suffix)
+    } else {
+      unfixedArguments = arguments
+      fixedArguments = []
+    }
+    
+    self.arguments = unfixedArguments.map { argument in
       if argument.first == "-" {
         let flags = argument[argument.index(after: argument.startIndex)..<argument.endIndex]
 
@@ -72,6 +84,7 @@ public final class ArgumentParser : ArgumentConvertible, CustomStringConvertible
 
       return .argument(argument)
     }
+    self.arguments.append(contentsOf: fixedArguments.map { .argument($0) })
   }
 
   public init(parser: ArgumentParser) throws {

--- a/Tests/CommanderTests/ArgumentParserSpec.swift
+++ b/Tests/CommanderTests/ArgumentParserSpec.swift
@@ -119,5 +119,30 @@ public func testArgumentParser() {
         try expect(values.count) == 0
       }
     }
+      $0.describe("positional arguments") {
+        $0.before {
+          parser = ArgumentParser(arguments: ["-a", "value1", "--", "-b", "value2"])
+        }
+        $0.it("should not count double dash into the arguments") {
+          try expect(parser.remainder.count) == 4
+          _ = try parser.shiftValue(for: "a" as ArgumentParser.Flag)
+          try expect(parser.remainder.count) == 2
+        }
+        $0.it("should not parse parameters as flags after the double dash") {
+          try expect(parser.hasFlag("a" as ArgumentParser.Flag)).to.beTrue()
+          try expect(parser.hasFlag("b" as ArgumentParser.Flag)).to.beFalse()
+          
+          _ = try parser.shiftValue(for: "a" as ArgumentParser.Flag)
+          let value = try parser.shiftValue(for: "b" as ArgumentParser.Flag)
+          try expect(value).to.beNil()
+        }
+        $0.it("should return parameters after the double dash as arguments") {
+          _ = try parser.shiftValue(for: "a" as ArgumentParser.Flag)
+          let value1 = parser.shift()
+          let value2 = parser.shift()
+          try expect(value1) == "-b"
+          try expect(value2) == "value2"
+        }
+      }
   }
 }


### PR DESCRIPTION
Adding support for bare double dash `--` (more info [here](https://unix.stackexchange.com/questions/11376/what-does-double-dash-mean-also-known-as-bare-double-dash))

Tokens coming after the `--` are always treated as arguments, even if they start with a `-` or `--`. In Commander, these can easily be parsed by adding a `VariadicArgument` to the end of the command configuration.