### PR TITLE
Add convenience method for clearing arguments

### DIFF
--- a/Sources/Commander/ArgumentParser.swift
+++ b/Sources/Commander/ArgumentParser.swift
@@ -280,4 +280,9 @@ public final class ArgumentParser : ArgumentConvertible, CustomStringConvertible
     
     return nil
   }
+
+  /// Clears all arguments
+  public func clear() {
+    arguments = []
+  }
 }

--- a/Tests/CommanderTests/ArgumentParserSpec.swift
+++ b/Tests/CommanderTests/ArgumentParserSpec.swift
@@ -159,4 +159,12 @@ let testArgumentParser: ((ContextType) -> Void) = {
       try expect(parser.description) == "-user -one"
     }
   }
+
+  $0.describe("clear") {
+    $0.it("clears arguments") {
+      try expect(parser.isEmpty).to.beFalse()
+      parser.clear()
+      try expect(parser.isEmpty).to.beTrue()
+    }
+  }
 }


### PR DESCRIPTION
This PR adds a convenience method to clear arguments in the `AgumentParser`. This is useful when we want to manually ignore all further arguments. Using `clear` we can prevent calling a `UsageError` for unknown arguments.