### PR TITLE
Fix swallowed error message in CommandRunner

### DIFF
--- a/Sources/Commander/CommandRunner.swift
+++ b/Sources/Commander/CommandRunner.swift
@@ -37,11 +37,8 @@ extension CommandType {
     } catch let error as ANSIConvertible {
       error.print()
       exit(1)
-    } catch let error as CustomStringConvertible {
-      ANSI.red.print(error.description, to: stderr)
-      exit(1)
     } catch {
-      ANSI.red.print("Unknown error occurred.", to: stderr)
+      ANSI.red.print("An error occurred: \(error)", to: stderr)
       exit(1)
     }
 


### PR DESCRIPTION
This fixes an issue where a non-`CustomStringConvertible` error type would get swallowed instead of printed. Since every value in Swift has a string representation (especially structs and enums), we can just use string interpolation on the unknown error.